### PR TITLE
Move typescript to dependencies, bump patch version for new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "release": "npm publish --access public"
   },
   "dependencies": {
-    "ts-node": "^9.1.1"
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.14.19",
-    "jest": "^26.6.3",
-    "typescript": "^4.1.3"
+    "jest": "^26.6.3"
   },
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interval/envoy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
I think this is the only thing actually causing https://github.com/interval/interval2/issues/234 ?

Because `ts-node` is a dependency we use at runtime, we also need to
specify `typescript` as a runtime dependency, because `ts-node` depends
on it.

Fixes an error reported by berry:

```sh
$ yarn add ../interval2/sdk-js/interval-sdk-v0.11.0-dev.tgz
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @interval/envoy@npm:1.0.1 doesn't provide typescript (pc4987), requested by ts-node
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: Done with warnings in 0s 66ms

$ yarn explain peer-requirements pc4987
➤ YN0000: @interval/envoy@npm:1.0.1 doesn't provide typescript, breaking the following requirements:

➤ YN0000: ts-node@npm:9.1.1 [d1057] → >=2.7 ✘
```